### PR TITLE
Added build to gitignore, showed students how to switch to their own …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# Build directory
+build/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ To build the demo, simply execute the following:
 ```bash
 git clone https://github.com/cjdb/basic_project.git
 cd basic_project
+git remote rename origin cjdb
+git remote add origin <your repository url here>
 mkdir -p build/debug
 cd build/debug
 cmake -DCMAKE_CXX_COMPILER=`which <your compiler here>` -DCMAKE_BUILD_TYPE=Debug ../..


### PR DESCRIPTION
I suspect students will have two issues:
* They will want to turn this into their assignment directory, and will probably want to know how to push to their own repository
* They will almost certainly accidentally push their build directory